### PR TITLE
Interpolation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,9 @@ const auto pose_a_in_world = a_from_world.Inverse();
 
 Quaternions have a couple things going for them. First, they use less space
 than a rotation matrix. So you save a little memory with each transform.
-Second, quaternions are faster for composing transforms. Don't believe me? Run
-the benchmark. Here's an example result:
+Second, quaternions are faster for composing transforms. Third, quaternions are
+faster for interpolating. Don't believe me? Run the benchmark. Here's an
+example result:
 
 ```text
 tim@computer:~/ttfrm$ make bench
@@ -171,13 +172,17 @@ Running Eigen::Isometry3d benchmarks over 100M iterations... Done!
 
 CPU usage summary:
   ttfrm::Tfrm<int> benchmarks:
-    Apply:   Took 0.831 s (8 ns average)
-    Compose: Took 2.706 s (27 ns average)
-    Inverse: Took 3.272 s (32 ns average)
+    Apply:   Took 0.816 s (8 ns average)
+    Compose: Took 2.681 s (26 ns average)
+    Inverse: Took 3.271 s (32 ns average)
+    Interp:  Took 2.359 s (23 ns average)
   Eigen::Isometry3d benchmarks:
     Apply:   Took 0.503 s (5 ns average)
-    Compose: Took 3.431 s (34 ns average)
+    Compose: Took 3.433 s (34 ns average)
     Inverse: Took 1.602 s (16 ns average)
+    Interp:  Took 4.692 s (469 ns average) [*]
+
+[*]: 10M iterations only. Includes required quaternion conversions for slerp.
 ...
 ```
 

--- a/tests/tfrm_test.cpp
+++ b/tests/tfrm_test.cpp
@@ -356,7 +356,7 @@ TEST(Tfrm, ComposePoseAccuracy)
   const auto& pose_b_in_world = world_from_b;
   const MyTfrm pose_b_in_a = world_from_a.Inverse() * pose_b_in_world;
   const ttfrm::Vec3 pose_b_in_a_trans = pose_b_in_a.Translation();
-  const ttfrm::Quat pose_b_in_a_rot = pose_b_in_a.Rotation().normalized();
+  const ttfrm::Quat pose_b_in_a_rot = pose_b_in_a.Rotation();
   EXPECT_NEAR(pose_b_in_a_trans.x(), -2.0, 1.0e-6);
   EXPECT_NEAR(pose_b_in_a_trans.y(), 0.0, 1.0e-6);
   EXPECT_NEAR(pose_b_in_a_trans.z(), 1.0, 1.0e-6);


### PR DESCRIPTION
Adds a function to interpolate between two transforms. Rotations are interpolated via `slerp`.

Updates tests and benchmarks.

The benchmark does not really do an "apples to apples" comparison. In order to do `slerp` with rotation matrices, they must first be converted into quaternions. Therefore, the `Isometry3d` benchmark includes the required quaternion conversions. (Not having to do these conversions in the `Tfrm` benchmark is an advantage of using quaternions from the start.)