### PR TITLE
Explicit frame pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ const quat rot = {0.7071, 0.0, -0.7071, 0.0};
 const vec3 trans = {1.0, 1.0, 1.0};
 
 // Transform to X from World
-const tfrm<std::string> x_from_world("x", "world", rot, trans);
+const tfrm<std::string> x_from_world(to_s("x") << from("world"), rot, trans);
 
 // Transform to Y from X
-const tfrm<std::string> y_from_x("y", "x", rot, trans);
+const tfrm<std::string> y_from_x(to_s("y") << from_s("x"), rot, trans);
 
 // Transform to Z from Y
-const tfrm<std::string> z_from_y("z", "y", rot, trans);
+const tfrm<std::string> z_from_y(to_s("z") << from_s("y"), rot, trans);
 
 // Compose transforms to get the transform to Z form World (?)
 const tfrm<std::string> z_from_world = z_from_y * x_from_world;

--- a/tests/spirograph_demo.cpp
+++ b/tests/spirograph_demo.cpp
@@ -12,34 +12,34 @@ constexpr double TAU = 2.0 * M_PI;
 constexpr std::size_t SCREEN_WIDTH = 800;
 constexpr std::size_t SCREEN_HEIGHT = 800;
 
-ttfrm::tfrm<std::string> circle_transform(const std::string& to_frame,
-                                          const std::string& from_frame, const double rr,
-                                          const double tt)
+ttfrm::tfrm<std::string> circle_transform(ttfrm::frame_pair<std::string> fp, double rr, double tt)
 {
   const double xx = rr * std::cos(TAU * tt);
   const double yy = rr * std::sin(TAU * tt);
   const double th = std::atan2(yy, xx);
   const ttfrm::quat rot = quat_from_euler_xyz({0.0, 0.0, th});
   const ttfrm::vec3 trans = {xx, yy, 0.0};
-  return ttfrm::tfrm<std::string>(to_frame, from_frame, rot, trans);
+  return ttfrm::tfrm<std::string>(std::move(fp), rot, trans);
 }
 
 std::vector<ttfrm::vec3> spirograph()
 {
+  using ttfrm::from_s;
+  using ttfrm::to_s;
   constexpr std::size_t NUM_STEPS = 10000;
   constexpr double R1 = 200.0;
   constexpr double R2 = 100.0;
   constexpr double R3 = 50.0;
   constexpr double R4 = 10.0;
   ttfrm::tfrm<std::string> corner_from_center = ttfrm::tfrm<std::string>::from_translation(
-      "corner", "center", {SCREEN_WIDTH / 2.0, SCREEN_HEIGHT / 2.0, 0.0});
+      to_s("corner") << from_s("center"), {SCREEN_WIDTH / 2.0, SCREEN_HEIGHT / 2.0, 0.0});
   std::vector<ttfrm::vec3> vecs;
   for (std::size_t ii = 0; ii < NUM_STEPS; ++ii) {
     const double tt = static_cast<double>(ii) / (NUM_STEPS - 1);
-    const auto center_from_c1 = circle_transform("center", "c1", R1, tt);
-    const auto c1_from_c2 = circle_transform("c1", "c2", R2, 32.0 * tt);
-    const auto c2_from_c3 = circle_transform("c2", "c3", R3, 64.0 * tt);
-    const auto c3_from_c4 = circle_transform("c3", "c4", R4, 64.0 * tt);
+    const auto center_from_c1 = circle_transform(to_s("center") << from_s("c1"), R1, tt);
+    const auto c1_from_c2 = circle_transform(to_s("c1") << from_s("c2"), R2, 32.0 * tt);
+    const auto c2_from_c3 = circle_transform(to_s("c2") << from_s("c3"), R3, 64.0 * tt);
+    const auto c3_from_c4 = circle_transform(to_s("c3") << from_s("c4"), R4, 64.0 * tt);
     const auto corner_from_c =
         corner_from_center * center_from_c1 * c1_from_c2 * c2_from_c3 * c3_from_c4;
     vecs.push_back(corner_from_c.translation());

--- a/tests/tfrm_bench.cpp
+++ b/tests/tfrm_bench.cpp
@@ -197,14 +197,15 @@ struct tfrm_interpolate_bench : public bench_func {
   ttfrm::tfrm<int> other_tf;
 
   explicit tfrm_interpolate_bench(const ttfrm::tfrm<int>& tf)
-      : tf(tf), other_tf(0, 0, tf.rotation().inverse(), 2.0 * tf.translation())
+      : tf(tf),
+        other_tf(ttfrm::to(0) << ttfrm::from(0), tf.rotation().inverse(), 2.0 * tf.translation())
   {
     // Do nothing
   }
 
   void operator()() override
   {
-    tf = tf.interpolate(0, other_tf, 0.01);
+    tf = tf.interpolate(ttfrm::to(0), other_tf, 0.01);
   }
 
   std::size_t get_result_hash() const override
@@ -314,7 +315,7 @@ void cpu_usage_info()
   std::cout << "////////////////////\n\n";
   const ttfrm::quat rot = quat_from_euler_xyz(rad_from_deg({45.0, 90.0, 20.0}));
   const ttfrm::vec3 trans = {2.0, 1.0, 0.0};
-  const ttfrm::tfrm<int> tf(0, 0, rot, trans);
+  const ttfrm::tfrm<int> tf(ttfrm::to(0) << ttfrm::from(0), rot, trans);
   const Eigen::Isometry3d iso = tf.as_isometry();
   std::cout << "Running ttfrm::tfrm<int> benchmarks over 100M iterations... ";
   std::cout << std::flush;

--- a/tests/tfrm_test.cpp
+++ b/tests/tfrm_test.cpp
@@ -9,11 +9,14 @@
 using my_frame_pair = ttfrm::frame_pair<std::string>;
 using my_tfrm = ttfrm::tfrm<std::string>;
 
+using ttfrm::from_s;
+using ttfrm::to_s;
+
 TEST(tfrm, construct)
 {
   const ttfrm::quat rot = ttfrm::quat::Identity();
   const ttfrm::vec3 trans = ttfrm::vec3::Zero();
-  const my_tfrm test_from_world("test", "world", rot, trans);
+  const my_tfrm test_from_world(to_s("test") << from_s("world"), rot, trans);
   EXPECT_EQ(test_from_world.to_frame(), "test");
   EXPECT_EQ(test_from_world.from_frame(), "world");
 }
@@ -22,7 +25,7 @@ TEST(tfrm, construct_copy)
 {
   const ttfrm::quat rot = ttfrm::quat::Identity();
   const ttfrm::vec3 trans = ttfrm::vec3::Zero();
-  const my_tfrm test_from_world("test", "world", rot, trans);
+  const my_tfrm test_from_world(to_s("test") << from_s("world"), rot, trans);
   const my_tfrm test_from_world2 = test_from_world;
   EXPECT_EQ(test_from_world2.to_frame(), "test");
   EXPECT_EQ(test_from_world2.from_frame(), "world");
@@ -32,7 +35,7 @@ TEST(tfrm, construct_move)
 {
   const ttfrm::quat rot = ttfrm::quat::Identity();
   const ttfrm::vec3 trans = ttfrm::vec3::Zero();
-  my_tfrm test_from_world("test", "world", rot, trans);
+  my_tfrm test_from_world(to_s("test") << from_s("world"), rot, trans);
   const my_tfrm test_from_world2 = std::move(test_from_world);
   EXPECT_EQ(test_from_world2.to_frame(), "test");
   EXPECT_EQ(test_from_world2.from_frame(), "world");
@@ -40,7 +43,7 @@ TEST(tfrm, construct_move)
 
 TEST(tfrm, identity)
 {
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   EXPECT_EQ(test_from_world.to_frame(), "test");
   EXPECT_EQ(test_from_world.from_frame(), "world");
 }
@@ -48,7 +51,7 @@ TEST(tfrm, identity)
 TEST(tfrm, from_rotation)
 {
   const ttfrm::quat rot = ttfrm::quat::Identity();
-  const my_tfrm test_from_world = my_tfrm::from_rotation("test", "world", rot);
+  const my_tfrm test_from_world = my_tfrm::from_rotation(to_s("test") << from_s("world"), rot);
   EXPECT_EQ(test_from_world.to_frame(), "test");
   EXPECT_EQ(test_from_world.from_frame(), "world");
 }
@@ -56,7 +59,7 @@ TEST(tfrm, from_rotation)
 TEST(tfrm, from_translation)
 {
   const ttfrm::vec3 trans = ttfrm::vec3::Zero();
-  const my_tfrm test_from_world = my_tfrm::from_translation("test", "world", trans);
+  const my_tfrm test_from_world = my_tfrm::from_translation(to_s("test") << from_s("world"), trans);
   EXPECT_EQ(test_from_world.to_frame(), "test");
   EXPECT_EQ(test_from_world.from_frame(), "world");
 }
@@ -68,15 +71,16 @@ TEST(tfrm, from_isometry)
   Eigen::Isometry3d iso_test_from_world;
   iso_test_from_world.prerotate(rot);
   iso_test_from_world.pretranslate(trans);
-  const my_tfrm test_from_world = my_tfrm::from_isometry("test", "world", iso_test_from_world);
+  const my_tfrm test_from_world =
+      my_tfrm::from_isometry(to_s("test") << from_s("world"), iso_test_from_world);
   EXPECT_EQ(test_from_world.to_frame(), "test");
   EXPECT_EQ(test_from_world.from_frame(), "world");
 }
 
 TEST(tfrm, assignment)
 {
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
-  my_tfrm test_from_world2 = my_tfrm::identity("junk1", "junk2");
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
+  my_tfrm test_from_world2 = my_tfrm::identity(to_s("junk1") << from_s("junk2"));
   test_from_world2 = test_from_world;
   EXPECT_EQ(test_from_world2.to_frame(), "test");
   EXPECT_EQ(test_from_world2.from_frame(), "world");
@@ -84,8 +88,8 @@ TEST(tfrm, assignment)
 
 TEST(tfrm, assignment_move)
 {
-  my_tfrm test_from_world = my_tfrm::identity("test", "world");
-  my_tfrm test_from_world2 = my_tfrm::identity("junk1", "junk2");
+  my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
+  my_tfrm test_from_world2 = my_tfrm::identity(to_s("junk1") << from_s("junk2"));
   test_from_world2 = std::move(test_from_world);
   EXPECT_EQ(test_from_world2.to_frame(), "test");
   EXPECT_EQ(test_from_world2.from_frame(), "world");
@@ -93,8 +97,8 @@ TEST(tfrm, assignment_move)
 
 TEST(tfrm, equality)
 {
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
-  const my_tfrm test_from_world2 = my_tfrm::identity("test", "world");
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
+  const my_tfrm test_from_world2 = my_tfrm::identity(to_s("test") << from_s("world"));
   EXPECT_TRUE(test_from_world == test_from_world2);
 }
 
@@ -102,16 +106,16 @@ TEST(tfrm, inequality)
 {
   const ttfrm::quat rot = ttfrm::quat::Identity();
   const ttfrm::vec3 trans = ttfrm::vec3::Zero();
-  const my_tfrm test_from_world("test", "world", rot, trans);
-  const my_tfrm abc_from_world("junk1", "world", rot, trans);
+  const my_tfrm test_from_world(to_s("test") << from_s("world"), rot, trans);
+  const my_tfrm abc_from_world(to_s("junk1") << from_s("world"), rot, trans);
   EXPECT_TRUE(test_from_world != abc_from_world);
-  const my_tfrm test_from_efg("test", "junk2", rot, trans);
+  const my_tfrm test_from_efg(to_s("test") << from_s("junk2"), rot, trans);
   EXPECT_TRUE(test_from_world != test_from_efg);
   const ttfrm::quat other_rot = quat_from_euler_xyz(rad_from_deg({45.0, 90.0, 20.0}));
-  const my_tfrm test_from_world2("test", "world", other_rot, trans);
+  const my_tfrm test_from_world2(to_s("test") << from_s("world"), other_rot, trans);
   EXPECT_TRUE(test_from_world != test_from_world2);
   const ttfrm::vec3 other_trans = {2.0, 1.0, 0.0};
-  const my_tfrm test_from_world3("test", "world", rot, other_trans);
+  const my_tfrm test_from_world3(to_s("test") << from_s("world"), rot, other_trans);
   EXPECT_TRUE(test_from_world != test_from_world3);
 }
 
@@ -119,27 +123,27 @@ TEST(tfrm, is_approx)
 {
   const ttfrm::quat rot = quat_from_euler_xyz(rad_from_deg({45.0, 90.0, 20.0}));
   const ttfrm::vec3 trans = {2.0, 1.0, 0.0};
-  const my_tfrm test_from_world("test", "world", rot, trans);
+  const my_tfrm test_from_world(to_s("test") << from_s("world"), rot, trans);
   EXPECT_TRUE(test_from_world.is_approx(test_from_world));
   const double fuzz = 1.0e-7;
   const ttfrm::quat other_rot = rot.slerp(fuzz, rot.inverse());
   const ttfrm::vec3 other_trans = (1.0 + fuzz) * trans;
-  const my_tfrm test_from_world2("test", "world", other_rot, trans);
+  const my_tfrm test_from_world2(to_s("test") << from_s("world"), other_rot, trans);
   EXPECT_FALSE(test_from_world == test_from_world2);
   EXPECT_TRUE(test_from_world.is_approx(test_from_world2));
-  const my_tfrm test_from_world3("test", "world", rot, other_trans);
+  const my_tfrm test_from_world3(to_s("test") << from_s("world"), rot, other_trans);
   EXPECT_FALSE(test_from_world == test_from_world3);
   EXPECT_TRUE(test_from_world.is_approx(test_from_world3));
   // Also test for different frames
-  const my_tfrm abs_from_world("junk1", "world", rot, trans);
+  const my_tfrm abs_from_world(to_s("junk1") << from_s("world"), rot, trans);
   EXPECT_FALSE(test_from_world.is_approx(abs_from_world));
-  const my_tfrm test_from_efg("test", "junk2", rot, trans);
+  const my_tfrm test_from_efg(to_s("test") << from_s("junk2"), rot, trans);
   EXPECT_FALSE(test_from_world.is_approx(test_from_efg));
 }
 
 TEST(tfrm, frames)
 {
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   const my_frame_pair fp = test_from_world.frames();
   EXPECT_EQ(fp.to_frame, "test");
   EXPECT_EQ(fp.from_frame, "world");
@@ -149,7 +153,7 @@ TEST(tfrm, rotation)
 {
   const ttfrm::quat rot = quat_from_euler_xyz(rad_from_deg({45.0, 90.0, 20.0}));
   const ttfrm::vec3 trans = {2.0, 1.0, 0.0};
-  const my_tfrm test_from_world("test", "world", rot, trans);
+  const my_tfrm test_from_world(to_s("test") << from_s("world"), rot, trans);
   const ttfrm::quat got_rot = test_from_world.rotation();
   static auto quat_equality = [](const ttfrm::quat& q1, const ttfrm::quat& q2) {
     return (q1.w() == q2.w() && q1.x() == q2.x() && q1.y() == q2.y() && q1.z() == q2.z());
@@ -161,14 +165,14 @@ TEST(tfrm, translation)
 {
   const ttfrm::quat rot = quat_from_euler_xyz(rad_from_deg({45.0, 90.0, 20.0}));
   const ttfrm::vec3 trans = {2.0, 1.0, 0.0};
-  const my_tfrm test_from_world("test", "world", rot, trans);
+  const my_tfrm test_from_world(to_s("test") << from_s("world"), rot, trans);
   const ttfrm::vec3 got_trans = test_from_world.translation();
   EXPECT_EQ(trans, got_trans);
 }
 
 TEST(tfrm, apply)
 {
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   const ttfrm::vec3 vec_in_world = {3.0, 4.0, 5.0};
   const ttfrm::vec3 vec_in_test = test_from_world.apply(vec_in_world);
   (void) vec_in_test;
@@ -176,7 +180,7 @@ TEST(tfrm, apply)
 
 TEST(tfrm, apply_multiply)
 {
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   const ttfrm::vec3 vec_in_world = {3.0, 4.0, 5.0};
   const ttfrm::vec3 vec_in_test = test_from_world * vec_in_world;
   (void) vec_in_test;
@@ -184,7 +188,7 @@ TEST(tfrm, apply_multiply)
 
 TEST(tfrm, apply_call)
 {
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   const ttfrm::vec3 vec_in_world = {3.0, 4.0, 5.0};
   const ttfrm::vec3 vec_in_test = test_from_world(vec_in_world);
   (void) vec_in_test;
@@ -192,7 +196,7 @@ TEST(tfrm, apply_call)
 
 TEST(tfrm, inverse)
 {
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   const my_tfrm world_from_test = test_from_world.inverse();
   EXPECT_EQ(world_from_test.to_frame(), "world");
   EXPECT_EQ(world_from_test.from_frame(), "test");
@@ -200,8 +204,8 @@ TEST(tfrm, inverse)
 
 TEST(tfrm, compose)
 {
-  const my_tfrm x_from_world = my_tfrm::identity("x", "world");
-  const my_tfrm test_from_x = my_tfrm::identity("test", "x");
+  const my_tfrm x_from_world = my_tfrm::identity(to_s("x") << from_s("world"));
+  const my_tfrm test_from_x = my_tfrm::identity(to_s("test") << from_s("x"));
   const my_tfrm test_from_world = test_from_x.compose(x_from_world);
   EXPECT_EQ(test_from_world.to_frame(), "test");
   EXPECT_EQ(test_from_world.from_frame(), "world");
@@ -209,15 +213,15 @@ TEST(tfrm, compose)
 
 TEST(tfrm, compose_bad)
 {
-  const my_tfrm x_from_world = my_tfrm::identity("x", "world");
-  const my_tfrm test_from_y = my_tfrm::identity("test", "y");
+  const my_tfrm x_from_world = my_tfrm::identity(to_s("x") << from_s("world"));
+  const my_tfrm test_from_y = my_tfrm::identity(to_s("test") << from_s("y"));
   EXPECT_THROW(const my_tfrm garbage = test_from_y.compose(x_from_world), ttfrm::compose_exception);
 }
 
 TEST(tfrm, compose_multiply)
 {
-  const my_tfrm x_from_world = my_tfrm::identity("x", "world");
-  const my_tfrm test_from_x = my_tfrm::identity("test", "x");
+  const my_tfrm x_from_world = my_tfrm::identity(to_s("x") << from_s("world"));
+  const my_tfrm test_from_x = my_tfrm::identity(to_s("test") << from_s("x"));
   const my_tfrm test_from_world = test_from_x * x_from_world;
   EXPECT_EQ(test_from_world.to_frame(), "test");
   EXPECT_EQ(test_from_world.from_frame(), "world");
@@ -225,8 +229,8 @@ TEST(tfrm, compose_multiply)
 
 TEST(tfrm, compose_call)
 {
-  const my_tfrm x_from_world = my_tfrm::identity("x", "world");
-  const my_tfrm test_from_x = my_tfrm::identity("test", "x");
+  const my_tfrm x_from_world = my_tfrm::identity(to_s("x") << from_s("world"));
+  const my_tfrm test_from_x = my_tfrm::identity(to_s("test") << from_s("x"));
   const my_tfrm test_from_world = test_from_x(x_from_world);
   EXPECT_EQ(test_from_world.to_frame(), "test");
   EXPECT_EQ(test_from_world.from_frame(), "world");
@@ -234,31 +238,31 @@ TEST(tfrm, compose_call)
 
 TEST(tfrm, interpolate)
 {
-  const my_tfrm x_from_world = my_tfrm::identity("x", "world");
-  const my_tfrm y_from_world = my_tfrm::identity("y", "world");
-  const my_tfrm test_from_world = x_from_world.interpolate("test", y_from_world, 0.77);
+  const my_tfrm x_from_world = my_tfrm::identity(to_s("x") << from_s("world"));
+  const my_tfrm y_from_world = my_tfrm::identity(to_s("y") << from_s("world"));
+  const my_tfrm test_from_world = x_from_world.interpolate(to_s("test"), y_from_world, 0.77);
   EXPECT_EQ(test_from_world.to_frame(), "test");
   EXPECT_EQ(test_from_world.from_frame(), "world");
 }
 
 TEST(tfrm, interpolate_bad)
 {
-  const my_tfrm x_from_world = my_tfrm::identity("x", "world");
-  const my_tfrm y_from_world = my_tfrm::identity("y", "junk");
-  EXPECT_THROW(const my_tfrm garbage = x_from_world.interpolate("test", y_from_world, 0.77),
+  const my_tfrm x_from_world = my_tfrm::identity(to_s("x") << from_s("world"));
+  const my_tfrm y_from_world = my_tfrm::identity(to_s("y") << from_s("junk"));
+  EXPECT_THROW(const my_tfrm garbage = x_from_world.interpolate(to_s("test"), y_from_world, 0.77),
                ttfrm::interpolate_exception);
 }
 
 TEST(tfrm, as_isometry)
 {
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   const Eigen::Isometry3d iso_test_from_world = test_from_world.as_isometry();
   (void) iso_test_from_world;
 }
 
 TEST(tfrm, to_string_tfrm)
 {
-  const my_tfrm tf = my_tfrm::identity("test", "world");
+  const my_tfrm tf = my_tfrm::identity(to_s("test") << from_s("world"));
   const std::string tf_str = ttfrm::to_string(tf);
   const std::string expected_str =
       "([test] <- [world], ROT: (W: 1.000000, X: 0.000000, Y: 0.000000, Z: 0.000000), TRANS: (X: "
@@ -268,7 +272,7 @@ TEST(tfrm, to_string_tfrm)
 
 TEST(tfrm, to_string_frame_pair)
 {
-  const my_frame_pair fp{"test", "world"};
+  const my_frame_pair fp = ttfrm::to_s("test") << ttfrm::from_s("world");
   const std::string tf_str = ttfrm::to_string(fp);
   const std::string expected_str = "([test] <- [world])";
   EXPECT_EQ(tf_str, expected_str);
@@ -278,7 +282,7 @@ TEST(tfrm, apply_accuracy)
 {
   const ttfrm::quat rot = quat_from_euler_xyz(rad_from_deg({45.0, 90.0, 20.0}));
   const ttfrm::vec3 trans = {2.0, 1.0, 0.0};
-  const my_tfrm test_from_world("test", "world", rot, trans);
+  const my_tfrm test_from_world(to_s("test") << from_s("world"), rot, trans);
   const ttfrm::vec3 vec_in_world = {3.0, 4.0, 5.0};
   const ttfrm::vec3 vec_in_test = test_from_world * vec_in_world;
   EXPECT_NEAR(vec_in_test.x(), 7.000000, 1.0e-6);
@@ -293,7 +297,8 @@ TEST(tfrm, from_isometry_accuracy)
   Eigen::Isometry3d iso_test_from_world = Eigen::Isometry3d::Identity();
   iso_test_from_world.prerotate(rot);
   iso_test_from_world.pretranslate(trans);
-  const my_tfrm test_from_world = my_tfrm::from_isometry("test", "world", iso_test_from_world);
+  const my_tfrm test_from_world =
+      my_tfrm::from_isometry(to_s("test") << from_s("world"), iso_test_from_world);
   const ttfrm::vec3 vec_in_world = {3.0, 4.0, 5.0};
   const ttfrm::vec3 vec_in_test = iso_test_from_world * vec_in_world;
   EXPECT_NEAR(vec_in_test.x(), 7.000000, 1.0e-6);
@@ -309,7 +314,7 @@ TEST(tfrm, inverse_accuracy)
 {
   const ttfrm::quat rot = quat_from_euler_xyz(rad_from_deg({45.0, 90.0, 20.0}));
   const ttfrm::vec3 trans = {2.0, 1.0, 0.0};
-  const my_tfrm test_from_world("test", "world", rot, trans);
+  const my_tfrm test_from_world(to_s("test") << from_s("world"), rot, trans);
   const my_tfrm world_from_test = test_from_world.inverse();
   const ttfrm::vec3 vec_in_world = {3.0, 4.0, 5.0};
   const ttfrm::vec3 vec_in_test = test_from_world * vec_in_world;
@@ -326,8 +331,8 @@ TEST(tfrm, compose_accuracy)
 {
   const ttfrm::quat rot = quat_from_euler_xyz(rad_from_deg({45.0, 90.0, 20.0}));
   const ttfrm::vec3 trans = {2.0, 1.0, 0.0};
-  const my_tfrm x_from_world("x", "world", rot, trans);
-  const my_tfrm test_from_x("test", "x", rot, trans);
+  const my_tfrm x_from_world(to_s("x") << from_s("world"), rot, trans);
+  const my_tfrm test_from_x(to_s("test") << from_s("x"), rot, trans);
   const my_tfrm test_from_world = test_from_x * x_from_world;
   const ttfrm::vec3 vec_in_world = {3.0, 4.0, 5.0};
   const ttfrm::vec3 vec_in_x = x_from_world * vec_in_world;
@@ -348,11 +353,11 @@ TEST(tfrm, compose_pose_accuracy)
 {
   const ttfrm::vec3 pose_a_trans = {0.0, 0.0, -1.0};
   const ttfrm::quat pose_a_rot = quat_from_euler_xyz(rad_from_deg({0.0, 90.0, 0.0}));
-  const my_tfrm world_from_a("world", "a", pose_a_rot, pose_a_trans);
+  const my_tfrm world_from_a(to_s("world") << from_s("a"), pose_a_rot, pose_a_trans);
   // `world_from_a` also known as `pose_a_in_world`
   const ttfrm::vec3 pose_b_trans = {1.0, 0.0, 1.0};
   const ttfrm::quat pose_b_rot = quat_from_euler_xyz(rad_from_deg({0.0, -90.0, 0.0}));
-  const my_tfrm world_from_b("world", "b", pose_b_rot, pose_b_trans);
+  const my_tfrm world_from_b(to_s("world") << from_s("b"), pose_b_rot, pose_b_trans);
   const auto& pose_b_in_world = world_from_b;
   const my_tfrm pose_b_in_a = world_from_a.inverse() * pose_b_in_world;
   const ttfrm::vec3 pose_b_in_a_trans = pose_b_in_a.translation();
@@ -369,11 +374,11 @@ TEST(tfrm, interpolate_accuracy)
 {
   const ttfrm::quat x_rot = quat_from_euler_xyz(rad_from_deg({45.0, 90.0, 20.0}));
   const ttfrm::vec3 x_trans = {2.0, 1.0, 0.0};
-  const my_tfrm x_from_world("x", "world", x_rot, x_trans);
+  const my_tfrm x_from_world(to_s("x") << from_s("world"), x_rot, x_trans);
   const ttfrm::quat y_rot = quat_from_euler_xyz(rad_from_deg({20.0, 45.0, 90.0}));
   const ttfrm::vec3 y_trans = {3.0, 4.0, 5.0};
-  const my_tfrm y_from_world("y", "world", y_rot, y_trans);
-  const my_tfrm test_from_world = x_from_world.interpolate("test", y_from_world, 0.77);
+  const my_tfrm y_from_world(to_s("y") << from_s("world"), y_rot, y_trans);
+  const my_tfrm test_from_world = x_from_world.interpolate(to_s("test"), y_from_world, 0.77);
   const ttfrm::quat test_from_world_rot = test_from_world.rotation();
   const ttfrm::quat expected_rot =
       quat_from_euler_xyz(rad_from_deg({14.443773, 54.984770, 84.443773}));
@@ -388,7 +393,7 @@ TEST(tfrm, as_isometry_accuracy)
 {
   const ttfrm::quat rot = quat_from_euler_xyz(rad_from_deg({45.0, 90.0, 20.0}));
   const ttfrm::vec3 trans = {2.0, 1.0, 0.0};
-  const my_tfrm test_from_world("test", "world", rot, trans);
+  const my_tfrm test_from_world(to_s("test") << from_s("world"), rot, trans);
   const Eigen::Isometry3d iso_test_from_world = test_from_world.as_isometry();
   const ttfrm::vec3 vec_in_world = {3.0, 4.0, 5.0};
   const ttfrm::vec3 vec_in_test = iso_test_from_world * vec_in_world;

--- a/tests/tfrm_tree_test.cpp
+++ b/tests/tfrm_tree_test.cpp
@@ -7,40 +7,43 @@
 using my_tfrm = ttfrm::tfrm<std::string>;
 using my_tfrm_tree = ttfrm::tfrm_tree<std::string>;
 
+using ttfrm::from_s;
+using ttfrm::to_s;
+
 TEST(tfrm_tree, construct)
 {
-  const my_tfrm_tree tf_tree("world");
+  const my_tfrm_tree tf_tree(from_s("world"));
   EXPECT_EQ(tf_tree.root_frame(), "world");
 }
 
 TEST(tfrm_tree, construct_copy)
 {
-  const my_tfrm_tree tf_tree("world");
+  const my_tfrm_tree tf_tree(from_s("world"));
   const my_tfrm_tree tf_tree2 = tf_tree;
   EXPECT_EQ(tf_tree2.root_frame(), "world");
 }
 
 TEST(tfrm_tree, construct_move)
 {
-  const my_tfrm_tree tf_tree("world");
+  const my_tfrm_tree tf_tree(from_s("world"));
   const my_tfrm_tree tf_tree2 = std::move(tf_tree);
   EXPECT_EQ(tf_tree2.root_frame(), "world");
 }
 
 TEST(tfrm_tree, insert)
 {
-  my_tfrm_tree tf_tree("world");
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  my_tfrm_tree tf_tree(from_s("world"));
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   tf_tree.insert(test_from_world);
 }
 
 TEST(tfrm_tree, insert_chain)
 {
-  my_tfrm_tree tf_tree("world");
-  const my_tfrm x_from_world = my_tfrm::identity("x", "world");
-  const my_tfrm y_from_x = my_tfrm::identity("y", "x");
-  const my_tfrm z_from_y = my_tfrm::identity("z", "y");
-  const my_tfrm test_from_z = my_tfrm::identity("test", "z");
+  my_tfrm_tree tf_tree(from_s("world"));
+  const my_tfrm x_from_world = my_tfrm::identity(to_s("x") << from_s("world"));
+  const my_tfrm y_from_x = my_tfrm::identity(to_s("y") << from_s("x"));
+  const my_tfrm z_from_y = my_tfrm::identity(to_s("z") << from_s("y"));
+  const my_tfrm test_from_z = my_tfrm::identity(to_s("test") << from_s("z"));
   tf_tree.insert(x_from_world);
   tf_tree.insert(y_from_x);
   tf_tree.insert(z_from_y);
@@ -49,26 +52,26 @@ TEST(tfrm_tree, insert_chain)
 
 TEST(tfrm_tree, insert_unrooted)
 {
-  my_tfrm_tree tf_tree("world");
-  const my_tfrm test_from_x = my_tfrm::identity("test", "x");
+  my_tfrm_tree tf_tree(from_s("world"));
+  const my_tfrm test_from_x = my_tfrm::identity(to_s("test") << from_s("x"));
   EXPECT_THROW(tf_tree.insert(test_from_x), ttfrm::insert_unrooted_exception);
 }
 
 TEST(tfrm_tree, insert_duplicate)
 {
-  my_tfrm_tree tf_tree("world");
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
-  const my_tfrm test_from_world2 = my_tfrm::identity("test", "world");
+  my_tfrm_tree tf_tree(from_s("world"));
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
+  const my_tfrm test_from_world2 = my_tfrm::identity(to_s("test") << from_s("world"));
   tf_tree.insert(test_from_world);
   EXPECT_THROW(tf_tree.insert(test_from_world2), ttfrm::insert_duplicate_exception);
 }
 
 TEST(tfrm_tree, insert_cycle)
 {
-  my_tfrm_tree tf_tree("world");
-  const my_tfrm x_from_world = my_tfrm::identity("x", "world");
-  const my_tfrm test_from_x = my_tfrm::identity("test", "x");
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  my_tfrm_tree tf_tree(from_s("world"));
+  const my_tfrm x_from_world = my_tfrm::identity(to_s("x") << from_s("world"));
+  const my_tfrm test_from_x = my_tfrm::identity(to_s("test") << from_s("x"));
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   tf_tree.insert(x_from_world);
   tf_tree.insert(test_from_x);
   EXPECT_THROW(tf_tree.insert(test_from_world), ttfrm::insert_cycle_exception);
@@ -76,75 +79,75 @@ TEST(tfrm_tree, insert_cycle)
 
 TEST(tfrm_tree, insert_cycle_to_self)
 {
-  my_tfrm_tree tf_tree("world");
-  const my_tfrm world_from_world = my_tfrm::identity("world", "world");
+  my_tfrm_tree tf_tree(from_s("world"));
+  const my_tfrm world_from_world = my_tfrm::identity(to_s("world") << from_s("world"));
   EXPECT_THROW(tf_tree.insert(world_from_world), ttfrm::insert_cycle_exception);
 }
 
 TEST(tfrm_tree, update)
 {
-  my_tfrm_tree tf_tree("world");
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  my_tfrm_tree tf_tree(from_s("world"));
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   tf_tree.insert(test_from_world);
   tf_tree.update(test_from_world);
 }
 
 TEST(tfrm_tree, update_chain)
 {
-  my_tfrm_tree tf_tree("world");
-  const my_tfrm x_from_world = my_tfrm::identity("x", "world");
-  my_tfrm y_from_x = my_tfrm::identity("y", "x");
-  const my_tfrm z_from_y = my_tfrm::identity("z", "y");
-  const my_tfrm test_from_z = my_tfrm::identity("test", "z");
+  my_tfrm_tree tf_tree(from_s("world"));
+  const my_tfrm x_from_world = my_tfrm::identity(to_s("x") << from_s("world"));
+  my_tfrm y_from_x = my_tfrm::identity(to_s("y") << from_s("x"));
+  const my_tfrm z_from_y = my_tfrm::identity(to_s("z") << from_s("y"));
+  const my_tfrm test_from_z = my_tfrm::identity(to_s("test") << from_s("z"));
   tf_tree.insert(x_from_world);
   tf_tree.insert(y_from_x);
   tf_tree.insert(z_from_y);
   tf_tree.insert(test_from_z);
-  y_from_x = my_tfrm::from_translation("y", "x", {2.0, 1.0, 0.0});
+  y_from_x = my_tfrm::from_translation(to_s("y") << from_s("x"), {2.0, 1.0, 0.0});
   tf_tree.update(y_from_x);
 }
 
 TEST(tfrm_tree, update_nonexistent_to_frame)
 {
-  my_tfrm_tree tf_tree("world");
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  my_tfrm_tree tf_tree(from_s("world"));
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   tf_tree.insert(test_from_world);
-  const my_tfrm junk1_from_world = my_tfrm::identity("junk1", "world");
+  const my_tfrm junk1_from_world = my_tfrm::identity(to_s("junk1") << from_s("world"));
   EXPECT_THROW(tf_tree.update(junk1_from_world), ttfrm::update_nonexistent_exception);
 }
 
 TEST(tfrm_tree, update_nonexistent_from_frame)
 {
-  my_tfrm_tree tf_tree("world");
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  my_tfrm_tree tf_tree(from_s("world"));
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   tf_tree.insert(test_from_world);
-  const my_tfrm test_from_junk2 = my_tfrm::identity("test", "junk2");
+  const my_tfrm test_from_junk2 = my_tfrm::identity(to_s("test") << from_s("junk2"));
   EXPECT_THROW(tf_tree.update(test_from_junk2), ttfrm::update_nonexistent_exception);
 }
 
 TEST(tfrm_tree, get)
 {
-  my_tfrm_tree tf_tree("world");
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  my_tfrm_tree tf_tree(from_s("world"));
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   tf_tree.insert(test_from_world);
-  const my_tfrm test_from_world2 = tf_tree.get("test", "world");
+  const my_tfrm test_from_world2 = tf_tree.get(to_s("test") << from_s("world"));
 }
 
 TEST(tfrm_tree, get_nonexistent_to_frame)
 {
-  my_tfrm_tree tf_tree("world");
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  my_tfrm_tree tf_tree(from_s("world"));
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   tf_tree.insert(test_from_world);
-  EXPECT_THROW(const my_tfrm test_from_world2 = tf_tree.get("junk1", "world"),
+  EXPECT_THROW(const my_tfrm test_from_world2 = tf_tree.get(to_s("junk1") << from_s("world")),
                ttfrm::get_nonexistent_exception);
 }
 
 TEST(tfrm_tree, get_nonexistent_from_frame)
 {
-  my_tfrm_tree tf_tree("world");
-  const my_tfrm test_from_world = my_tfrm::identity("test", "world");
+  my_tfrm_tree tf_tree(from_s("world"));
+  const my_tfrm test_from_world = my_tfrm::identity(to_s("test") << from_s("world"));
   tf_tree.insert(test_from_world);
-  EXPECT_THROW(const my_tfrm test_from_world2 = tf_tree.get("test", "junk2"),
+  EXPECT_THROW(const my_tfrm test_from_world2 = tf_tree.get(to_s("test") << from_s("junk2")),
                ttfrm::get_nonexistent_exception);
 }
 


### PR DESCRIPTION
Attempts to add more type safety to target and source frames for construction of transforms. Reworks API to use frame pairs instead of accepting individual frames.