### PR TITLE
Update build for Jammy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,19 @@
 version: 2
 
 jobs:
+  build_jammy:
+    docker:
+      - image: tprk77/ttfrmci:jammy
+    steps:
+      - checkout
+      - run:
+          name: Build tests and utilities
+          command: |
+            make CPP_STD=c++17 BUILD_GRAPHICS=false
+      - run:
+          name: Run the tests
+          command: |
+            make check
   build_bionic:
     docker:
       - image: tprk77/ttfrmci:bionic
@@ -48,6 +61,7 @@ workflows:
   version: 2
   build_and_coverage:
     jobs:
+      - build_jammy
       - build_bionic
       - build_xenial
       - coverage:

--- a/.circleci/ttfrmci/DockerfileJammy
+++ b/.circleci/ttfrmci/DockerfileJammy
@@ -1,0 +1,36 @@
+# tprk77/ttfrmci
+
+FROM cimg/base:2023.06-22.04
+
+USER root
+WORKDIR /
+
+# Install build tools (CMake is necessary to detect libfmt-dev)
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        clang \
+        cmake \
+        g++ \
+        git \
+        ninja-build \
+        pkg-config \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel \
+        python3-yaml \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Meson
+RUN pip3 install meson==1.1.1
+
+# Install dependencies
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        libeigen3-dev \
+        libfmt-dev \
+        libgtest-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+USER circleci
+WORKDIR /home/circleci/project

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,10 @@ endif
 
 # Important build variables
 VERBOSE ?=
+CPP_STD ?=
 BUILD_GRAPHICS ?=
-MESON_FLAGS ?= $(if $(BUILD_GRAPHICS),-Dgraphics=$(BUILD_GRAPHICS))
+MESON_FLAGS ?= $(if $(BUILD_GRAPHICS),-Dgraphics=$(BUILD_GRAPHICS)) \
+        $(if $(CPP_STD),-Dcpp_std=$(CPP_STD))
 NINJA_FLAGS ?= $(if $(VERBOSE),-v)
 
 # Automatically collect all sources
@@ -22,8 +24,9 @@ TTFRM_SRCS := $(shell find $(TTFRM_SRC_DIRS) -type f -regex ".*\.[ch]pp$$")
 
 all: build/build.sentinel
 
+# Create the build directory (don't actually build)
 build:
-> meson $(MESON_FLAGS) build
+> meson setup $(MESON_FLAGS) build
 
 build/build.sentinel: $(TTFRM_SRCS) | build
 > ninja $(NINJA_FLAGS) -C build


### PR DESCRIPTION
Updates build to run on Jammy, i.e., Ubuntu 22.04. Adds Dockerfile for new Jammy container. Adds variable to Makefile to build with a newer C++ standard, i.e., C++17. (Note that C++11 is still supported.)